### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/modules/system/apps/virtualisation.nix
+++ b/modules/system/apps/virtualisation.nix
@@ -1,7 +1,7 @@
 { ... }:
 
 {
-  # https://nixos.wiki/wiki/Virt-manager
+  # https://wiki.nixos.org/wiki/Virt-manager
   virtualisation.libvirtd.enable = true;
   programs.virt-manager.enable = true;
   virtualisation.spiceUSBRedirection.enable = true;
@@ -20,6 +20,6 @@
     };
   };
 
-  # https://nixos.wiki/wiki/Flatpak
+  # https://wiki.nixos.org/wiki/Flatpak
   # services.flatpak.enable = true;
 }

--- a/modules/system/hardware/accelerated_video_playback.nix
+++ b/modules/system/hardware/accelerated_video_playback.nix
@@ -1,6 +1,6 @@
 { pkgs, ... }:
 
-# https://nixos.wiki/wiki/Accelerated_Video_Playback
+# https://wiki.nixos.org/wiki/Accelerated_Video_Playback
 {
   hardware.opengl = {
     extraPackages = with pkgs; [

--- a/modules/system/hardware/intel.nix
+++ b/modules/system/hardware/intel.nix
@@ -1,6 +1,6 @@
 { pkgs, ... }:
 
-# https://nixos.wiki/wiki/Accelerated_Video_Playback
+# https://wiki.nixos.org/wiki/Accelerated_Video_Playback
 {
   hardware.opengl = {
     extraPackages = with pkgs; [


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️